### PR TITLE
Slide out stats region on toggling details

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -984,6 +984,10 @@ ul {
     overflow: hidden
 }
 
+#map.full-height {
+    position: unset !important;
+}
+
 .map-inner {
     -ms-flex: 1;
     flex: 1;
@@ -1234,7 +1238,13 @@ ul {
     display: -ms-flexbox;
     display: flex;
     padding: 1rem;
-    background-color: #334a51
+    background-color: #334a51;
+    transform: translateY(0);
+    transition: transform 0.55s ease-in-out;
+}
+
+.stats.slideout {
+    transform: translateY(100%);
 }
 
 @media (max-width:900px) {

--- a/src/js/App.js
+++ b/src/js/App.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var $ = window.$;
 var _ = window._;
 var Backbone = window.Backbone;
 var MapView = window.MapView;
@@ -11,14 +12,17 @@ window.App = Backbone.View.extend({
         this.mapView = null;
         this.regionListView = null;
         this.regionDetailsView = null;
+        this.$statsRegion = $('.stats');
 
         this.emptyDetailsView = this.emptyDetailsView.bind(this);
         this.fadeInListView = this.fadeInListView.bind(this);
         this.toggleDetails = this.toggleDetails.bind(this);
+        this.slideOutStatsRegion = _.once(this.slideOutStatsRegion).bind(this);
 
         this.listenTo(this.model, 'change:detailsVisible', this.toggleDetails);
         this.listenToOnce(this.model, 'change:regionList', this.createRegionList);
         this.listenToOnce(this.model, 'change:baseMapTilesUrl', this.createMapView);
+        this.listenToOnce(this.model, 'change:detailsVisible', this.slideOutStatsRegion);
 
         this.model.fetch();
         this.render();
@@ -29,7 +33,10 @@ window.App = Backbone.View.extend({
     },
 
     createMapView: function() {
-        this.mapView = new MapView({ model: this.model });
+        this.mapView = new MapView({
+            model: this.model,
+            slideOutStatsRegion: this.slideOutStatsRegion,
+        });
         this.mapView.render();
     },
 
@@ -59,6 +66,20 @@ window.App = Backbone.View.extend({
             this.regionDetailsView.$el.fadeOut(200);
             _.delay(this.emptyDetailsView, 200);
             _.delay(this.fadeInListView, 200);
+        }
+    },
+
+    slideOutStatsRegion: function() {
+        var $statsRegion = this.$statsRegion;
+        var model = this.model;
+
+        if ($statsRegion && this.mapView.$el) {
+            $statsRegion.addClass('slideout');
+            this.mapView.$el.addClass('full-height');
+            _.delay(function() {
+                $statsRegion.hide();
+                model.set('statsVisible', false);
+            }, 500);
         }
     }
 });

--- a/src/js/models.js
+++ b/src/js/models.js
@@ -17,6 +17,7 @@ window.AppModel = Backbone.Model.extend({
     url: 'config.json',
 
     defaults: {
+        statsVisible: true,
         detailsVisible: false,
         selectedRegion: null,
         initialMapCenter: null,

--- a/src/js/views.js
+++ b/src/js/views.js
@@ -6,9 +6,13 @@ var _ = window._;
 var Backbone = window.Backbone;
 
 window.MapView = Backbone.View.extend({
-    initialize: function() {
+    el: '#map',
+
+    initialize: function(options) {
         this.map = null;
+        this.slideOutStatsRegion = options.slideOutStatsRegion;
         this.listenTo(this.model, 'change:selectedRegion', this.panBaseMap);
+        this.listenToOnce(this.model, 'change:statsVisible', this.resetMapSize);
     },
 
     render: function() {
@@ -25,6 +29,7 @@ window.MapView = Backbone.View.extend({
         }).addTo(map);
 
         this.map = map;
+        this.map.once('moveend', this.slideOutStatsRegion);
 
         return this;
     },
@@ -39,6 +44,13 @@ window.MapView = Backbone.View.extend({
             this.model.get('initialMapZoom');
 
         this.map.flyTo(newCenter, newZoom);
+    },
+
+    resetMapSize: function() {
+        var animate = true;
+        if (this.map) {
+            this.map.invalidateSize(animate);
+        }
     },
 });
 


### PR DESCRIPTION
## Overview

This PR dismisses the stats region via slide-out the first time the user clicks on one of the detail items or moves the map.

Connects #8

## Demo

![tnc-slideout-statsbar](https://user-images.githubusercontent.com/4165523/32182852-11615d3e-bd6e-11e7-9d73-9b959ba9f827.gif)

## Notes

We could potentially tweak the animation transitions some more; right now the slideout element has a .35s transition through which it moves off screen, paired with a 350 ms `_.delay` call to hide it altogether and trigger invalidating the map size.

Also: this is targeted at your config branch right now. My thinking was we could merge this into that, then merge the whole thing back into develop. I haven't encountered any obvious bugs on the config branch yet, but can check in a formal PR.

## Testing Instructions
- get this branch, then `server`
- visit localhost:8642 and interact with the map. Verify that the stats bar slides out & remains gone for that session
- reload the app and click on one of the details items; verify that the stats bar slides out & remains gone there too.