### PR TITLE
Make StatsView configurable

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -149,5 +149,25 @@
                 }
             ]
         }
+    ],
+    "statsList": [
+        {
+            "label": "Engagement",
+            "stat": 100,
+            "secondaryLabel": "Communities",
+            "description": "across 11 countries trained in Coastal resilience action"
+        },
+        {
+            "label": "Awareness",
+            "stat": 90,
+            "secondaryLabel": "Publications",
+            "description": "making the case for nature–based solutions that reduce risk"
+        },
+        {
+            "label": "Action",
+            "stat": 25,
+            "secondaryLabel": "Decision support tools",
+            "description": "implemented for restoration and conservation efforts"
+        }
     ]
 }

--- a/src/index.html
+++ b/src/index.html
@@ -55,49 +55,7 @@
         </div>
         <div class="data-container">
             <div class="map-inner" id="map"></div>
-            <div class="stats" id="stats-region">
-                <div class="stats--inner">
-                    <div class="stat--section">
-                        <div class="stat--label">
-                            Engagement
-                        </div>
-                        <div class="stat--total">
-                            100 <span>
-                                    Communities
-                            </span>
-                        </div>
-                        <div class="stat--info">
-                            across 11 countries trained in Coastal resilience action
-                        </div>
-                    </div>
-                    <div class="stat--section">
-                        <div class="stat--label">
-                            Awareness
-                        </div>
-                        <div class="stat--total">
-                            90 <span>
-                                    Publications
-                            </span>
-                        </div>
-                        <div class="stat--info">
-                            making the case for nature–based solutions that reduce risk
-                        </div>
-                    </div>
-                    <div class="stat--section">
-                        <div class="stat--label">
-                            Action
-                        </div>
-                        <div class="stat--total">
-                            25 <span>
-                                    Decision support tools
-                            </span>
-                        </div>
-                        <div class="stat--info">
-                            implemented for restoration and conservation efforts
-                        </div>
-                    </div>
-                </div>
-            </div>
+            <div class="stats" id="stats-region"></div>
         </div>
     </div>
     <div id="app-modal-view"></div>
@@ -172,6 +130,26 @@
             </div>
         </div>
     </div>
+
+    <script type="text/template" id="statsViewTemplate">
+        <div class="stats--inner">
+            <% _.each(statItems, function(statItem) { %>
+                <div class="stat--section">
+                    <div class="stat--label">
+                        <%= statItem.label %>
+                    </div>
+                    <div class="stat--total">
+                        <%= statItem.stat %> <span>
+                            <%= statItem.secondaryLabel %>
+                        </span>
+                    </div>
+                    <div class="stat--info">
+                        <%= statItem.description %>
+                    </div>
+                </div>
+            <% }) %>
+        </div>
+    </script>
 
     <script type="text/template" id="regionListTemplate">
         <div class="location--list" id="region-location-list">

--- a/src/js/App.js
+++ b/src/js/App.js
@@ -6,13 +6,14 @@ var Backbone = window.Backbone;
 var MapView = window.MapView;
 var RegionListView = window.RegionListView;
 var RegionDetailsView = window.RegionDetailsView;
+var StatsView = window.StatsView;
 
 window.App = Backbone.View.extend({
     initialize: function() {
         this.mapView = null;
         this.regionListView = null;
         this.regionDetailsView = null;
-        this.$statsRegion = $('.stats');
+        this.statsView = null;
 
         this.emptyDetailsView = this.emptyDetailsView.bind(this);
         this.fadeInListView = this.fadeInListView.bind(this);
@@ -24,6 +25,7 @@ window.App = Backbone.View.extend({
         this.listenToOnce(this.model, 'change:regionList', this.createRegionList);
         this.listenToOnce(this.model, 'change:baseMapTilesUrl', this.createMapView);
         this.listenToOnce(this.model, 'change:detailsVisible', this.slideOutStatsRegion);
+        this.listenToOnce(this.model, 'change:statsList', this.createStatsView);
 
         this.model.fetch();
         this.render();
@@ -44,6 +46,11 @@ window.App = Backbone.View.extend({
     createRegionList: function() {
         this.regionListView = new RegionListView({ model: this.model });
         this.regionListView.render();
+    },
+
+    createStatsView: function() {
+        this.statsView = new StatsView({ model: this.model });
+        this.statsView.render();
     },
 
     emptyDetailsView: function() {
@@ -120,15 +127,15 @@ window.App = Backbone.View.extend({
     },
 
     slideOutStatsRegion: function() {
-        var $statsRegion = this.$statsRegion;
-        var model = this.model;
+        var self = this;
 
-        if ($statsRegion && this.mapView.$el) {
-            $statsRegion.addClass('slideout');
+        if (this.statsView.$el && this.mapView.$el) {
+            this.statsView.$el.addClass('slideout');
             this.mapView.$el.addClass('full-height');
             _.delay(function() {
-                $statsRegion.hide();
-                model.set('statsVisible', false);
+                self.statsView.$el.hide();
+                self.model.set('statsVisible', false);
+                self.statsView.$el.empty();
             }, 500);
         }
     }

--- a/src/js/models.js
+++ b/src/js/models.js
@@ -18,6 +18,7 @@ window.AppModel = Backbone.Model.extend({
 
     defaults: {
         statsVisible: true,
+        statsList: null,
         detailsVisible: false,
         selectedRegion: null,
         initialMapCenter: null,

--- a/src/js/views.js
+++ b/src/js/views.js
@@ -176,3 +176,30 @@ window.RegionDetailsView = Backbone.View.extend({
     },
 });
 
+window.StatsView = Backbone.View.extend({
+    el: '#stats-region',
+
+    template: _.template($('#statsViewTemplate').html()),
+
+    render: function() {
+        var statsList = this.model.get('statsList');
+        // To ensure the app always shows 3 and only 3 stat items, take the
+        // first three configured stat items if the number's >= 3; if there are
+        // fewer than 3 configured stat items, add up to 3 placeholders.
+        var statItems = statsList.length >= 3 ? _.take(statsList, 3) :
+            statsList.concat(_.map(_.range(statsList.length, 3), function() {
+                return {
+                    label: 'Label',
+                    stat: 1,
+                    secondaryLabel: 'secondaryLabel',
+                    description: 'description',
+                };
+            }));
+
+        this.$el.html(this.template({
+            statItems: statItems,
+        }));
+
+        return this;
+    },
+});


### PR DESCRIPTION
## Overview

This PR enables configuring the stats view from the `config.json` file. To accomplish this we derive a StatsView from Backbone.view, then hydrate it from the configuration file. This also entailed some adjustments to the stats region dismissal logic, but it still visibly works the same way.

If more than 3 stats items are provided in the list, we drop everything after the third; if fewer than 3 are supplied, we pad the list with some placeholder values such that it will have 3.

Connects #11

## Testing Instructions
- get this branch, then `./scripts/server` and verify that the stats view appears correctly
- update the config file to include some additional stats items, then refresh the app and verify that only the first three in the list are loaded
- drop some elements from the stats list until it has 0-2 elements and verify that you see the placeholder text in place of the missing list items