### PR TITLE
Adjust Network Site links

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -206,7 +206,7 @@
                         <%= sr.title %>
                     </div>
                     <img src="<%= sr.image %>" alt="location background image">
-                    <a href="<%= sr.mapUrl %>">
+                    <a href="<%= sr.mapUrl %>" target="_blank">
                         <span class="sr-only">
                             Open map
                         </span>

--- a/src/index.html
+++ b/src/index.html
@@ -43,9 +43,9 @@
                 <div id="region-details-view"></div>
             </div>
             <div class="sidebar--footer">
-                <a href="" target="_blank">
+                <a href="https://www.nature.org/about-us/governance/terms-of-use/index.htm?redirect=https-301&src=f9" target="_blank">
                     Legal Disclosure
-                </a> | <a href="#" target="_blank">
+                </a> | <a href="https://www.nature.org/about-us/governance/privacy-policy.xml?redirect=https-301" target="_blank">
                     Privacy Statement
                 </a>
                 <br>


### PR DESCRIPTION
## Overview

This PR updates the link behavior from the network site:

First commit adjusts the legal and privacy links to point to the same links as the existing network site.

Second commit sets the region links to open their maps in new tabs.

Connects #10 
Connects #19 

## Testing
- get this branch, then `server` and visit 8642
- verify that the legal and privacy links point to the same urls as on http://maps.coastalresilience.org/network/
- verify that the region links open their maps in new tabs