### PR TITLE
Enable configurable partner site links

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -169,5 +169,77 @@
             "secondaryLabel": "Decision support tools",
             "description": "implemented for restoration and conservation efforts"
         }
+    ],
+    "partnerModalLinks": [
+        {
+            "partner": "ASFPM",
+            "url": "http://www.floods.org/",
+            "image": "ASFPM-Logo-full-color.jpg"
+        },
+        {
+            "partner": "Azavea",
+            "url": "https://www.azavea.com/",
+            "image": "azavea-logo.png"
+        },
+        {
+            "partner": "CISR",
+            "url": "#",
+            "image": "cisr_logo.png"
+        },
+        {
+            "partner": "Esri",
+            "url": "https://www.esri.com/",
+            "image": "esri-10GlobeLogo_sRGBflat300.jpg"
+        },
+        {
+            "partner": "GDPC",
+            "url": "http://www.preparecenter.org/",
+            "image": "GDPC Logo Final CMYK.jpg"
+        },
+        {
+            "partner": "IFRC",
+            "url": "http://www.ifrc.org/",
+            "image": "IFRC.jpeg"
+        },
+        {
+            "partner": "Microsoft",
+            "url": "https://www.microsoft.com/",
+            "image": "msft.jpg"
+        },
+        {
+            "partner": "Natural Capital Project",
+            "url": "https://www.naturalcapitalproject.org/",
+            "image": "NatCapLogo.png"
+        },
+        {
+            "partner": "NOAA",
+            "url": "http://www.noaa.gov/",
+            "image": "NOAA_logo_color_broadcast2.jpg"
+        },
+        {
+            "partner": "SpatialDev",
+            "url": "http://spatialdev.com/",
+            "image": "SpatialDev.jpeg"
+        },
+        {
+            "partner": "The Nature Conservancy",
+            "url": "https://www.nature.org/",
+            "image": "TNCLogoPrimary_RGB2.jpg"
+        },
+        {
+            "partner": "UNU",
+            "url": "https://ehs.unu.edu/",
+            "image": "UNU-EHS_3c.jpg"
+        },
+        {
+            "partner": "USGS",
+            "url": "https://www.usgs.gov/",
+            "image": "USGSlogo.jpg"
+        },
+        {
+            "partner": "USM",
+            "url": "https://home.usm.edu/",
+            "image": "usm_logo.png"
+        }
     ]
 }

--- a/src/index.html
+++ b/src/index.html
@@ -82,54 +82,19 @@
                     </p>
                 </div>
             </div>
-            <div class="modal-split">
-                <div class="modal-container--inner partner-logos">
-                    <a href="#" target="_blank">
-                        <img src="assets/images/partners/ASFPM-Logo-full-color.jpg" alt="">
-                    </a>
-                    <a href="#" target="_blank">
-                        <img src="assets/images/partners/azavea-logo.png" alt="">
-                    </a>
-                    <a href="#" target="_blank">
-                        <img src="assets/images/partners/cisr_logo.png" alt="">
-                    </a>
-                    <a href="#" target="_blank">
-                        <img src="assets/images/partners/esri-10GlobeLogo_sRGBflat300.jpg" alt="">
-                    </a>
-                    <a href="#" target="_blank">
-                        <img src="assets/images/partners/GDPC Logo Final CMYK.jpg" alt="">
-                    </a>
-                    <a href="#" target="_blank">
-                        <img src="assets/images/partners/IFRC.jpeg" alt="">
-                    </a>
-                    <a href="#" target="_blank">
-                        <img src="assets/images/partners/msft.jpg" alt="">
-                    </a>
-                    <a href="#" target="_blank">
-                        <img src="assets/images/partners/NatCapLogo.png" alt="">
-                    </a>
-                    <a href="#" target="_blank">
-                        <img src="assets/images/partners/NOAA_logo_color_broadcast2.jpg" alt="">
-                    </a>
-                    <a href="#" target="_blank">
-                        <img src="assets/images/partners/SpatialDev.jpeg" alt="">
-                    </a>
-                    <a href="#" target="_blank">
-                        <img src="assets/images/partners/TNCLogoPrimary_RGB2.jpg" alt="">
-                    </a>
-                    <a href="#" target="_blank">
-                        <img src="assets/images/partners/UNU-EHS_3c.jpg" alt="">
-                    </a>
-                    <a href="#" target="_blank">
-                        <img src="assets/images/partners/USGSlogo.jpg" alt="">
-                    </a>
-                    <a href="#" target="_blank">
-                        <img src="assets/images/partners/usm_logo.png" alt="">
-                    </a>
-                </div>
-            </div>
+            <div class="modal-split" id="partner-modal-region"></div>
         </div>
     </div>
+
+    <script type="text/template" id="partnerModalViewTemplate">
+        <div class="modal-container--inner partner-logos">
+            <% _.each(partnerLinks, function(partnerLinkItem) { %>
+                <a href="<%= partnerLinkItem.url %>" target="_blank">
+                    <img src="assets/images/partners/<%= partnerLinkItem.image %>" alt="<%= partnerLinkItem.partner %>">
+                </a>
+            <% }) %>
+        </div>
+    </script>
 
     <script type="text/template" id="statsViewTemplate">
         <div class="stats--inner">

--- a/src/js/App.js
+++ b/src/js/App.js
@@ -7,6 +7,7 @@ var MapView = window.MapView;
 var RegionListView = window.RegionListView;
 var RegionDetailsView = window.RegionDetailsView;
 var StatsView = window.StatsView;
+var PartnerModalView = window.PartnerModalView;
 
 window.App = Backbone.View.extend({
     initialize: function() {
@@ -14,6 +15,7 @@ window.App = Backbone.View.extend({
         this.regionListView = null;
         this.regionDetailsView = null;
         this.statsView = null;
+        this.partnerModalView = null;
 
         this.emptyDetailsView = this.emptyDetailsView.bind(this);
         this.fadeInListView = this.fadeInListView.bind(this);
@@ -26,6 +28,7 @@ window.App = Backbone.View.extend({
         this.listenToOnce(this.model, 'change:baseMapTilesUrl', this.createMapView);
         this.listenToOnce(this.model, 'change:detailsVisible', this.slideOutStatsRegion);
         this.listenToOnce(this.model, 'change:statsList', this.createStatsView);
+        this.listenToOnce(this.model, 'change:partnerModalLinks', this.createPartnerModalView);
 
         this.model.fetch();
         this.render();
@@ -51,6 +54,11 @@ window.App = Backbone.View.extend({
     createStatsView: function() {
         this.statsView = new StatsView({ model: this.model });
         this.statsView.render();
+    },
+
+    createPartnerModalView: function() {
+        this.partnerModalView = new PartnerModalView({ model: this.model });
+        this.partnerModalView.render();
     },
 
     emptyDetailsView: function() {

--- a/src/js/models.js
+++ b/src/js/models.js
@@ -19,6 +19,7 @@ window.AppModel = Backbone.Model.extend({
     defaults: {
         statsVisible: true,
         statsList: null,
+        partnerModalLinks: null,
         detailsVisible: false,
         selectedRegion: null,
         initialMapCenter: null,

--- a/src/js/views.js
+++ b/src/js/views.js
@@ -203,3 +203,17 @@ window.StatsView = Backbone.View.extend({
         return this;
     },
 });
+
+window.PartnerModalView = Backbone.View.extend({
+    el: '#partner-modal-region',
+
+    template: _.template($('#partnerModalViewTemplate').html()),
+
+    render: function() {
+        this.$el.html(this.template({
+            partnerLinks: this.model.get('partnerModalLinks'),
+        }));
+
+        return this;
+    }
+});


### PR DESCRIPTION
## Overview

This PR enables configuring the partners modal from the config.json file; there we add an array of objects comprising a `url`, a `partner` to use as alt text, and an `image` designating the name of the image in `assets/partners` for use in the modal.

Connects #20

## Notes

I set up all of the links I could find, but I wasn't quite sure what CISR was so I left that one without a specific url for now.

Only the second commit's from this work; the first one's from the StatsView. Wanted to avoid rebasing the `config` file as much as possible.

## Testing Instructions
- get this branch, then `server` and visit :8642
- open the modal and verify that you see the partner links. These should all be clickable and all but the CISR one should open a new tab to the link in the config file