### PR TITLE
Set top CSS rule for close button

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -939,6 +939,7 @@ ul {
     position: absolute;
     right: 2rem;
     width: 4rem;
+    top: 1.5rem;
     height: 4rem;
     border-radius: 50%;
     cursor: pointer;


### PR DESCRIPTION
## Overview

This PR fixes a bug whereby the region details view close button was misaligned in Firefox. To fix it I added a `top: 1.5rem;` CSS rule to the button's class, which ensures it's positioned properly in FF, Chrome, Safari, and IE11.

Connects #17 

## Demo

Before:

![screen shot 2017-11-06 at 3 52 55 pm](https://user-images.githubusercontent.com/4165523/32463357-a24dccfa-c30a-11e7-8888-e6e5344adbe3.png)

After:

![screen shot 2017-11-06 at 3 53 21 pm](https://user-images.githubusercontent.com/4165523/32463364-a72c7744-c30a-11e7-8c40-379496d6b1af.png)

## Testing Instructions
- get this branch, then `server`
- visit localhost:8642 in FF, Chrome, Safari, and IE11 and verify that the region details view header's close button is properly aligned
