### PR TITLE
Render regions MapServer layer

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -5,6 +5,8 @@
     "baseMapTilesMaxZoom": 18,
     "baseMapTilesUrl": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}",
     "baseMapTilesAttribution": "Tiles &copy; Esri &mdash; Esri, DeLorme, NAVTEQ, TomTom, Intermap, iPC, USGS, FAO, NPS, NRCAN, GeoBase, Kadaster NL, Ordnance Survey, Esri Japan, METI, Esri China (Hong Kong), and the GIS User Community",
+    "regionLayerUrl": "http://services.coastalresilience.org:6080/arcgis/rest/services/Network/Sites/MapServer",
+    "regionLayerOpacity": 0.8,
     "regionList": [
         {
             "title": "Global Platform, World Risk, Conservation Atlas",

--- a/src/index.html
+++ b/src/index.html
@@ -221,6 +221,7 @@
     <script src="https://unpkg.com/leaflet@1.0.0/dist/leaflet.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/backbone.js/1.3.3/backbone-min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/esri-leaflet/2.1.1/esri-leaflet.js"></script>
     <script src="assets/vendor/bs-util.js"></script>
     <script src="assets/vendor/bs-modal.js"></script>
     <script src="js/App.js"></script>

--- a/src/js/models.js
+++ b/src/js/models.js
@@ -27,6 +27,8 @@ window.AppModel = Backbone.Model.extend({
         baseMapTilesUrl: null,
         baseMapTilesAttribution: null,
         regionList: null,
+        regionLayerUrl: null,
+        regionLayerOpacity: null,
     },
 
     initialize: function() {

--- a/src/js/views.js
+++ b/src/js/views.js
@@ -28,6 +28,11 @@ window.MapView = Backbone.View.extend({
             ext: 'png',
         }).addTo(map);
 
+        L.esri.dynamicMapLayer({
+            url: this.model.get('regionLayerUrl'),
+            opacity: this.model.get('regionLayerOpacity'),
+        }).addTo(map);
+
         this.map = map;
         this.map.once('moveend', this.slideOutStatsRegion);
 


### PR DESCRIPTION
## Overview

This PR adds the region layer shown on the existing network site to the new network site. To accomplish this we bring in L.Esri from a CDN and then create an `L.esri.dynamicMapLayer` as usual, using the url & opacity values from the `config.json` file.

Connects #14

## Demo

![screen shot 2017-11-06 at 4 09 22 pm](https://user-images.githubusercontent.com/4165523/32464113-f4326f38-c30c-11e7-95cf-8bdf160334a8.png)

## Notes

Enabling the opacity configuration may have been unnecessary -- and I can drop it if so.

## Testing Instructions
- get this branch, then `server`
- visit localhost:8642 and verify that you see the regions layer when the map loads
