### PR TITLE
Add web.config

### DIFF
--- a/src/web.config
+++ b/src/web.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <system.webServer>
+        <staticContent>
+            <mimeMap fileExtension=".json" mimeType="application/json" />
+        </staticContent>
+    </system.webServer>
+</configuration>


### PR DESCRIPTION
## Overview

This file is required so that IIS serves JSON.

It is based on the web.config file from the previous version of the site.

### Notes

Adding this file fixed the deployment on TNC's servers.

## Testing Instructions

- Verify that the file matches the [file](https://github.com/CoastalResilienceNetwork/tnc-network-site-deprecated/blob/master/src/web.config) in the old network site.
