### PR TITLE
Replace StatsView animation with $.slideToggle

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -985,10 +985,6 @@ ul {
     overflow: hidden
 }
 
-#map.full-height {
-    position: unset !important;
-}
-
 .map-inner {
     -ms-flex: 1;
     flex: 1;
@@ -1270,12 +1266,6 @@ ul {
     display: flex;
     padding: .7rem;
     background-color: #334a51;
-    transform: translateY(0);
-    transition: transform 0.55s ease-in-out;
-}
-
-.stats.slideout {
-    transform: translateY(100%);
 }
 
 @media (max-width:900px) {

--- a/src/index.html
+++ b/src/index.html
@@ -55,7 +55,9 @@
         </div>
         <div class="data-container">
             <div class="map-inner" id="map"></div>
-            <div class="stats" id="stats-region"></div>
+            <div id="stats-slideout-region">
+                <div class="stats" id="stats-region"></div>
+            </div>
         </div>
     </div>
     <div id="app-modal-view"></div>

--- a/src/js/App.js
+++ b/src/js/App.js
@@ -136,15 +136,15 @@ window.App = Backbone.View.extend({
 
     slideOutStatsRegion: function() {
         var self = this;
-
-        if (this.statsView.$el && this.mapView.$el) {
-            this.statsView.$el.addClass('slideout');
-            this.mapView.$el.addClass('full-height');
-            _.delay(function() {
-                self.statsView.$el.hide();
-                self.model.set('statsVisible', false);
-                self.statsView.$el.empty();
-            }, 500);
+        if (this.statsView.$el) {
+            $('#stats-slideout-region').slideToggle({
+                duration: 'slow',
+                easing: 'swing',
+                complete: function() {
+                    self.statsView.$el.hide();
+                    self.statsView.$el.empty();
+                }
+            });
         }
     }
 });

--- a/src/js/models.js
+++ b/src/js/models.js
@@ -17,7 +17,6 @@ window.AppModel = Backbone.Model.extend({
     url: 'config.json',
 
     defaults: {
-        statsVisible: true,
         statsList: null,
         partnerModalLinks: null,
         detailsVisible: false,

--- a/src/js/views.js
+++ b/src/js/views.js
@@ -23,7 +23,6 @@ window.MapView = Backbone.View.extend({
         this.slideOutStatsRegion = options.slideOutStatsRegion;
         this.listenTo(this.model, 'change:selectedRegion', this.panBaseMap);
         this.listenTo(this.model, 'change:selectedRegion', this.updateMarkers);
-        this.listenToOnce(this.model, 'change:statsVisible', this.resetMapSize);
         this.markers = L.layerGroup();
 
         // Custom icon for markers
@@ -68,13 +67,6 @@ window.MapView = Backbone.View.extend({
             this.model.get('initialMapZoom');
 
         this.map.flyTo(newCenter, newZoom);
-    },
-
-    resetMapSize: function() {
-        var animate = true;
-        if (this.map) {
-            this.map.invalidateSize(animate);
-        }
     },
 
     updateMarkers: function() {


### PR DESCRIPTION
## Overview

This PR re-implements the stats view slideout animation which we'd inadvertently broken. I redid this using jQuery `.slideToggle` which allowed simplifying the code a bit while also making the animation smoother.

Connects #29

## Demo

![tnc-site-animation-statsview](https://user-images.githubusercontent.com/4165523/32512260-744302c0-c3c4-11e7-855e-dd950305f84e.gif)

## Notes

The duration's configurable with a number of ms as well as `'slow'`;

The extra `div` around the stats region is there because `slideToggle` works on the `display` attribute by transitioning it from `block` to `none`, but since the region element has a display of `flex`, applying it directly to that element wouldn't animate smoothly.

## Testing Instructions
- get this branch, then `server`
- in Chrome, FF, Safari, and IE11, check that the StatsView slides out properly when...
   - interacting with the map for the first time
   - selecting a region from the list
