### PR TITLE
Add cibuild script & .travis.yml release deployment step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ typings/
 # prototype stuff
 prototype/dist/
 prototype/package-lock.json
+
+# cibuild output
+*.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,16 @@ install:
 
 script:
     - ./scripts/lint
+
+before_deploy:
+    - ./scripts/cibuild
+
+deploy:
+    provider: releases
+    api_key:
+        secure: $GITHUB_TOKEN
+    file: 'tnc-network-site-${TRAVIS-TAG}.zip'
+    skip-cleanup: true
+    on:
+        tags: true
+        repo: CoastalResilienceNetwork/tnc-network-site

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -ex
+
+function usage() {
+    echo -n \
+    "Usage: $(basename "$0")
+Build application for staging or a release.
+"
+}
+
+function cibuild() {
+    if [ -z ${TRAVIS_TAG} ]
+    then
+        if [[ -n "${GIT_COMMIT}" ]]; then
+            GIT_COMMIT="${GIT_COMMIT:0:7}"
+        else
+            GIT_COMMIT="$(git rev-parse --short HEAD)"
+        fi
+        zip -r tnc-network-site-${GIT_COMMIT}.zip src/
+    else
+        mv src/ tnc-network-site/
+        zip -r tnc-network-site-${TRAVIS-TAG}.zip tnc-network-site/
+    fi
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+        cibuild
+    fi
+fi


### PR DESCRIPTION
## Overview

This PR adds a cibuild script along with a TravisCI deployment step to zip & upload the file to GitHub releases on making a new release.

Connects #12

## Notes

I used `travis setup releases` from the Travis command line tool to configure the GitHub key; it's encrypted & stored as an environment variable in the build job.

## Testing

I'm not sure what is the best way to test the actual release build step but to test parts of this:

- run `./scripts/cibuild` locally and verify that the command creates a zipped version of the release assets in a file that substitutes the git sha for the release tag

- check the build for this branch -- https://travis-ci.org/CoastalResilienceNetwork/tnc-network-site/builds -- and restart a new build. Verify that it completes successfully and that you see

```sh
Setting environment variables from repository settings
$ export GITHUB_TOKEN=[secure]
```

in the output without an error
