### PR TITLE
Legal Disclosure -> Terms of Use

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -44,8 +44,8 @@
                 <div id="region-details-view"></div>
             </div>
             <div class="sidebar--footer">
-                <a href="https://www.nature.org/about-us/governance/terms-of-use/index.htm?redirect=https-301&src=f9" target="_blank">
-                    Legal Disclosure
+                <a href="http://coastalresilience.org/terms-of-use/" target="_blank">
+                    Terms of Use
                 </a> | <a href="https://www.nature.org/about-us/governance/privacy-policy.xml?redirect=https-301" target="_blank">
                     Privacy Statement
                 </a>


### PR DESCRIPTION
## Overview

- rename "Legal Disclosure" link anchor text to "Terms of Use"
- update terms of use link


Connects #33

## Demo

![screen shot 2017-11-14 at 4 10 48 pm](https://user-images.githubusercontent.com/4165523/32805373-34015110-c957-11e7-9eb9-2ac2ea9484bf.png)

## Testing
- get this branch, then `server`
- visit 8642 and verify that the "Legal Disclosure" link now reads "Terms of Use" and that it points to the Coastal Resilience Terms of Use page