### PR TITLE
Update README.md release instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ rules.
 
 ### Creating a Release with Git Flow
 
+This project uses git flow for releases of changes to site framework source
+code. Prior to making a release, we should also ask TNC whether there are
+any outstanding uncommitted configuration changes they'd like to have
+included in a versioned release.
+
 You can [find the latest version of `git-flow` to install here](https://github.com/petervanderdoes/gitflow-avh).
 
 Once it's installed, you'll need to enable `git flow` in your local version of


### PR DESCRIPTION
## Overview

This PR adjusts the README's release section to note that we use git flow for formal releases to framework source code changes (but not necessarily for configuration changes).

It also adds a suggestion that we check with TNC prior to making a release to see whether there are any configuration changes they'd like to have incorporated in the release.

Connects #34

## Testing Instructions
- verify that the new release instructions are accurate
- verify that the wiki's "Configuration" page accurately describes the structure of the `config.json` file: https://github.com/CoastalResilienceNetwork/tnc-network-site/wiki/Configuration
- verify that the wiki's "Deployment" page accurately describes the steps TNC should take to change, commit, and deploy a new configuration: https://github.com/CoastalResilienceNetwork/tnc-network-site/wiki/Deployment
