### PR TITLE
Add version to Travis release bundle

### DIFF
--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -19,7 +19,7 @@ function cibuild() {
         zip -r tnc-network-site-${GIT_COMMIT}.zip src/
     else
         mv src/ tnc-network-site/
-        zip -r tnc-network-site-${TRAVIS-TAG}.zip tnc-network-site/
+        zip -r tnc-network-site-${TRAVIS_TAG}.zip tnc-network-site/
     fi
 }
 


### PR DESCRIPTION
## Overview

This PR fixes a bug whereby the release version wasn't being added to the zipfile created by TravisCI. Instead the version number was replaced with `true` -- caused by a `_`/`-` typo in the second use of `TRAVIS_TAG` 

Connects #12 

## Notes & Testing

For comparison see the `TRAVIS_TAG` environment variable here:

https://github.com/WikiWatershed/mmw-geoprocessing/blob/develop/.travis.yml#L13

Note also build job log here -- https://travis-ci.org/CoastalResilienceNetwork/tnc-network-site/builds/300280777 -- shows the `TRAVIS_TAG` variable exists as `1.0.1` and that the `mv src/ tnc-network-site/` codepath's getting executed.

Also: run `./scripts/cibuild` locally and check that the `GIT_COMMIT` sha's added to the output there.