### PR TITLE
Adjust artifact filename

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ deploy:
     provider: releases
     api_key:
         secure: $GITHUB_TOKEN
-    file: 'tnc-network-site-${TRAVIS-TAG}.zip'
+    file: 'tnc-network-site.zip'
     skip-cleanup: true
     on:
         tags: true

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -19,7 +19,7 @@ function cibuild() {
         zip -r tnc-network-site-${GIT_COMMIT}.zip src/
     else
         mv src/ tnc-network-site/
-        zip -r tnc-network-site-${TRAVIS_TAG}.zip tnc-network-site/
+        zip -r tnc-network-site.zip tnc-network-site/
     fi
 }
 


### PR DESCRIPTION
## Overview

#41 broke the release deploy altogether since now Travis can't find the file:

https://travis-ci.org/CoastalResilienceNetwork/tnc-network-site/builds/303143815

This PR fixes that by dropping the Travis tag from the build altogether.

Connects #41

## Testing
- verify that the filename created in `cibuild` is identical to the filename in `.travis.yml`