### PR TITLE
Refactor use of models and views, and add subregion fly-to transitions

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -957,6 +957,22 @@ ul {
     margin-bottom: 2rem
 }
 
+.location--description a {
+    margin: 0 auto 20px auto;
+    display: none;
+    width: 105px;
+}
+
+@media (max-width: 900px) {
+    .location--description a {
+        display: block;
+    }
+}
+
+#subregion-list .location--description {
+    display: none;
+}
+
 .logo img {
     max-width: 10rem
 }
@@ -1054,6 +1070,10 @@ ul {
 
 .leaflet-popup-tip-container {
     display: none;
+}
+
+.leaflet-popup-scrolled {
+  border: none;
 }
 
 .marker-popup strong {

--- a/src/config.json
+++ b/src/config.json
@@ -20,14 +20,16 @@
                     "description": "The temperate southern coast of Australia is home to hundreds of bays and estuaries containing important habitats like shellfish reefs, mangrove forests, seagrass beds and saltmarshes. The Nature Conservancy Australia is working to repair these coastal habitats and restore their critical natural services with a current focus on shellfish reef restoration.",
                     "image": "assets/images/locations/victoria-australia.svg",
                     "mapUrl": "http://coastalresilience.org/project/victoria-australia/",
-                    "mapCenter": [-37.81, 144.96]
+                    "mapCenter": [-37.81, 144.96],
+                    "mapZoom": 6
                 },
                 {
                     "title": "Western Australia",
                     "description": "Restoration of marine habitats in the Peel region of Western Australia begins with outreach and data collection in order to visualize and prioritize efforts to protect valuable mangroves, salt marches, seagrasses, and shellfish reefs. This project in the Peel-Harvey estuary launches in March, 2018, with a series of workshops on different approaches to restore these marine habitats.",
                     "image": "assets/images/locations/western-australia.svg",
                     "mapUrl": "http://coastalresilience.org/project/western-australia/",
-                    "mapCenter": [-31.95, 115.86]
+                    "mapCenter": [-31.95, 115.86],
+                    "mapZoom": 6
                 }
             ]
         },
@@ -43,28 +45,32 @@
                     "description": "While the Dominican Republic has prioritized climate change adaptation, challenges to implementation persist from insufficient baseline data to financial gaps. TNC and IFRC will develop and test an innovative adaptation toolkit that will promote better decision making around disaster risk management and climate adaptation. This project launches January, 2018.",
                     "image": "assets/images/locations/dominican-republic.svg",
                     "mapUrl": "http://coastalresilience.org/project/dominican-republic/",
-                    "mapCenter": [18.73, -70.16]
+                    "mapCenter": [18.73, -70.16],
+                    "mapZoom": 6
                 },
                 {
                     "title": "Grenada, St. Vincent, and the Grenadines",
                     "description": "Demonstrating that governments and communities of small island states can enhance their resilience to climate change by protecting, restoring and effectively managing their marine and coastal ecosystems and strengthening local capacity for adaptation",
                     "image": "assets/images/locations/grenada.svg",
                     "mapUrl": "http://maps.coastalresilience.org/gsvg/",
-                    "mapCenter": [12.83, -61.04]
+                    "mapCenter": [12.83, -61.04],
+                    "mapZoom": 6
                 },
                 {
                     "title": "Jamaica",
                     "description": "The Small Island Developing States (SIDS) of the Caribbean are among the world’s most vulnerable to the impacts of climate change. While these losses are expected to grow, ecosystem-based adaptation can significantly reduce risk and avert economic losses. This project, a collaboration between TNC and IFRC, launches in January, 2018.",
                     "image": "assets/images/locations/jamaica.svg",
                     "mapUrl": "http://coastalresilience.org/project/jamaica/",
-                    "mapCenter": [18.10, -77.29]
+                    "mapCenter": [18.10, -77.29],
+                    "mapZoom": 6
                 },
                 {
                     "title": "U.S Virgin Islands",
                     "description": "In the US Virgin Islands, high resolution satellite imagery and GIS-based models are being used to identify and prioritize high risk and vulnerable coastal and marine sites subject to the effects of sea level rise, increasing storm surge and intensity, and altered precipitation patterns. The impacts of future SLR and storm surge scenarios are being validated by incorporating community perception, knowledge and historic events as a baseline to better understand how ecosystem-based adaptation solutions can help increase people and nature’s resilience to these impacts.",
                     "image": "assets/images/locations/virgin-islands.svg",
                     "mapUrl": "http://maps.coastalresilience.org/usvi/",
-                    "mapCenter": [17.72, -64.78]
+                    "mapCenter": [17.72, -64.78],
+                    "mapZoom": 6
                 }
             ]
         },
@@ -80,7 +86,8 @@
                     "description": "The goal of the Resilient Coastal Cities project in Semarang is to enhance local collaboration and problem solving to support effective climate change adaption.",
                     "image": "assets/images/locations/java-indonesia.svg",
                     "mapUrl": "http://coastalresilience.org/project/indonesia/",
-                    "mapCenter": [-7.00, 110.50]
+                    "mapCenter": [-7.00, 110.50],
+                    "mapZoom": 6
                 }
             ]
         },
@@ -97,7 +104,8 @@
                     "description": "The Mesomerican Reef supports multi-billion dollar tourism and fisheries industries, key income for Mexico, Belize, Guatemala and Honduras. Two million people live along the coast, rapidly developing despite being threatened by tropical storms and sea level rise. Partners in this Coastal Resilience project are working with governments, real state developers, tourism and fisheries sectors to adopt practices that better conserves natural coastlines while reducing people´s vulnerability to climate events.",
                     "image": "assets/images/locations/mesomerican-reef.svg",
                     "mapUrl": "http://maps.coastalresilience.org/mar",
-                    "mapCenter": [17.41, -86.75]
+                    "mapCenter": [17.41, -86.75],
+                    "mapZoom": 6
                 }
             ]
         },
@@ -113,77 +121,88 @@
                     "description": "Helping California’s coastal communities plan for resilience in the face of sea level rise",
                     "image": "assets/images/locations/california.svg",
                     "mapUrl": "http://maps.coastalresilience.org/california",
-                    "mapCenter": [35.23, -119.34]
+                    "mapCenter": [35.23, -119.34],
+                    "mapZoom": 6
                 },
                 {
                     "title": "Connecticut",
                     "description": "Visualizing coastal impacts, planning wisely for the future, taking action today",
                     "image": "assets/images/locations/connecticut-new-york.svg",
                     "mapUrl": "http://maps.coastalresilience.org/connecticut",
-                    "mapCenter": [41.18, -72.82]
+                    "mapCenter": [41.18, -72.82],
+                    "mapZoom": 6
                 },
                 {
                     "title": "Gulf of Mexico",
                     "description": "With its high incidence of storms and hurricanes and valuable ecological and economic resources, the Gulf region is a high-risk area with great potential to demonstrate natural risk reduction solutions. The Coastal Resilience approach and tools have been applied Gulf-wide and at specific sites, including those that help identify where to implement oyster reef restoration to meet social and ecological goals. Oyster restoration demonstration projects with partners like the National Oceanic and Atmospheric Administration (NOAA) and Army Corps of Engineers (ACOE) creates a strong base for replication and scaling-up to larger projects.",
                     "image": "assets/images/locations/gulf-of-mexico.svg",
                     "mapUrl": "http://maps.coastalresilience.org/gulfmex",
-                    "mapCenter": [29, -93.34]
+                    "mapCenter": [29, -93.34],
+                    "mapZoom": 6
                 },
                 {
                     "title": "Hawaii",
                     "description": "",
                     "image": "assets/images/locations/hawaii.svg",
                     "mapUrl": "http://maps.coastalresilience.org/hawaii",
-                    "mapCenter": [19.5, -156]
+                    "mapCenter": [19.5, -156],
+                    "mapZoom": 6
                 },
                 {
                     "title": "Maine",
                     "description": "Coastal Resilience is a web mapping tool that allows you to examine nature’s role in reducing coastal risks and opportunities for habitat conservation in Maine",
                     "image": "assets/images/locations/maine.svg",
                     "mapUrl": "http://maps.coastalresilience.org/maine",
-                    "mapCenter": [44.5, -69]
+                    "mapCenter": [44.5, -69],
+                    "mapZoom": 6
                 },
                 {
                     "title": "New Jersey",
                     "description": "Using natural infrastructure to build resiliency in New Jersey’s coastal communities",
                     "image": "assets/images/locations/new-jersey.svg",
                     "mapUrl": "http://maps.coastalresilience.org/newjersey",
-                    "mapCenter": [39.95, -74.40]
+                    "mapCenter": [39.95, -74.40],
+                    "mapZoom": 6
                 },
                 {
                     "title": "New York",
                     "description": "Providing New York with the right tools, information and resources to help reduce community vulnerability, plan responsibly, and protect natural resources.",
                     "image": "assets/images/locations/connecticut-new-york.svg",
                     "mapUrl": "http://maps.coastalresilience.org/newyork",
-                    "mapCenter": [40.6, -73.4]
+                    "mapCenter": [40.6, -73.4],
+                    "mapZoom": 6
                 },
                 {
                     "title": "North Carolina",
                     "description": "Identifying nature-based solutions for reducing risk in coastal communities",
                     "image": "assets/images/locations/north-carolina.svg",
                     "mapUrl": "http://maps.coastalresilience.org/northcarolina",
-                    "mapCenter": [34.5, -78]
+                    "mapCenter": [34.5, -78],
+                    "mapZoom": 6
                 },
                 {
                     "title": "Southeast Florida",
                     "description": "Restoring natural areas so they can protect vulnerable island communities",
                     "image": "assets/images/locations/florida.svg",
                     "mapUrl": "http://maps.coastalresilience.org/seflorida",
-                    "mapCenter": [25.85, -80.85]
+                    "mapCenter": [25.85, -80.85],
+                    "mapZoom": 6
                 },
                 {
                     "title": "Virginia",
                     "description": "Coastal Resilience is a decision-support tool that incorporates the best available science and local data to enable communities to visualize the risks imposed by sea-level rise and storm surge on the people, economy, and coastal habitats of the Eastern Shore and identify nature-based solutions for enhancing resilience and reducing risks where possible",
                     "image": "assets/images/locations/virginia.svg",
                     "mapUrl": "http://maps.coastalresilience.org/virginia",
-                    "mapCenter": [37.5, -75.8]
+                    "mapCenter": [37.5, -75.8],
+                    "mapZoom": 6
                 },
                 {
                     "title": "Washington",
                     "description": "With the Coastal Resilience/Floodplains by Design decision support tools, users can explore data and spatial analysis results for the rivers and shorelines of Washington from Puget Sound to the Outer Coast. These tools provide managers and planners mechanisms to explore the role of natural habitat in risk reduction along marine and fresh water shorelines to inform local restoration projects and development planning.",
                     "image": "assets/images/locations/washington.svg",
                     "mapUrl": "http://maps.coastalresilience.org/pugetsound",
-                    "mapCenter": [47.89, -122.47]
+                    "mapCenter": [47.89, -122.47],
+                    "mapZoom": 6
                 }
             ]
         }

--- a/src/index.html
+++ b/src/index.html
@@ -15,7 +15,7 @@
     <meta content="#ffffff" name="theme-color">
     <link href="assets/images/favicon.ico?" rel="shortcut icon" type="image/x-icon">
     <title>
-        Coastal Resilience – Mapping portal
+        Coastal Resilience – Mapping portal
     </title>
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,600,700" rel="stylesheet">
     <link href="https://unpkg.com/leaflet@1.0.0/dist/leaflet.css" rel="stylesheet">
@@ -151,15 +151,16 @@
     </script>
 
     <script type="text/template" id="subregionDetailsTemplate">
-        <div class="location--title">
-            <%= title %>
+        <div class="location">
+            <div class="location--title">
+                <%= title %>
+            </div>
+            <img src="<%= image %>" alt="location background image">
         </div>
-        <img src="<%= image %>" alt="location background image">
-        <a href="<%= mapUrl %>" target="_blank">
-            <span class="sr-only">
-                Open map
-            </span>
-        </a>
+        <p class="subregion location--description" data-title="<%= title %>">
+            <%= description %>
+            <a class="btn btn-primary" href="<%= mapUrl %>" target="_blank">Open map</a>
+        </p>
     </script>
 
     <script type="text/template" id="markerPopupTemplate">

--- a/src/index.html
+++ b/src/index.html
@@ -123,19 +123,19 @@
             <p>
                 At consectetur, reprehenderit ad distinctio sapiente obcaecati facilis dolor possimus officia incidunt consequatur in sed dignissimos neque.
             </p>
-            <% _.each(regionList, function(region) { %>
-                <div class="location" demo-js-parent-location id="<%= region.title %>">
-                    <div class="location--title" id="<%= region.title %>">
-                        <%= region.title %>
-                    </div>
-                    <img src="<%= region.image %>" alt="<%= region.title %>">
-                </div>
-            <% }) %>
+            <div id="region-list-items"></div>
         </div>
     </script>
 
+    <script type="text/template" id="regionListItemTemplate">
+        <div class="location--title" id="<%= title %>">
+            <%= title %>
+        </div>
+        <img src="<%= image %>" alt="<%= title %>">
+    </script>
+
     <script type="text/template" id="regionDetailsTemplate">
-        <div class="location active" demo-js-parent-location="" style="">
+        <div class="location active">
             <div class="location--title">
                 <%= title %>
             </div>
@@ -146,20 +146,20 @@
             <p class="location--description">
                 <%= description %>
             </p>
-            <% _.each(subregions, function(sr) { %>
-                <div class="location">
-                    <div class="location--title">
-                        <%= sr.title %>
-                    </div>
-                    <img src="<%= sr.image %>" alt="location background image">
-                    <a href="<%= sr.mapUrl %>" target="_blank">
-                        <span class="sr-only">
-                            Open map
-                        </span>
-                    </a>
-                </div>
-            <% }) %>
+            <div id="subregion-list"></div>
         </div>
+    </script>
+
+    <script type="text/template" id="subregionDetailsTemplate">
+        <div class="location--title">
+            <%= title %>
+        </div>
+        <img src="<%= image %>" alt="location background image">
+        <a href="<%= mapUrl %>" target="_blank">
+            <span class="sr-only">
+                Open map
+            </span>
+        </a>
     </script>
 
     <script type="text/template" id="markerPopupTemplate">

--- a/src/js/models.js
+++ b/src/js/models.js
@@ -7,7 +7,8 @@ window.SubregionDetailsModel = Backbone.Model.extend({
         title: null,
         description: null,
         mapUrl: null,
-        image: null
+        image: null,
+        selected: false,
     },
 });
 
@@ -53,5 +54,16 @@ window.AppModel = Backbone.Model.extend({
     getSelectedRegion: function() {
         return this.get('regionList')
             .filter({ selected: true })[0];
+    },
+
+    getSelectedSubregion: function() {
+        var selectedRegion = this.getSelectedRegion();
+
+        if (selectedRegion) {
+            return selectedRegion.get('subregions')
+                .filter({ selected: true })[0];
+        }
+
+        return null;
     }
 });

--- a/src/js/models.js
+++ b/src/js/models.js
@@ -1,16 +1,36 @@
 'use strict';
 
-var _ = window._;
 var Backbone = window.Backbone;
 
-var RegionDetailsModel = Backbone.Model.extend({
+window.SubregionDetailsModel = Backbone.Model.extend({
     defaults: {
         title: null,
         description: null,
         mapUrl: null,
+        image: null
+    },
+});
+
+window.SubregionsCollection = Backbone.Collection.extend({
+    model: window.SubregionDetailsModel
+});
+
+window.RegionDetailsModel = Backbone.Model.extend({
+    defaults: {
+        title: null,
+        description: null,
         image: null,
         subregions: null,
+        selected: false
     },
+
+    initialize: function() {
+        this.set('subregions', new window.SubregionsCollection(this.get('subregions')));
+    }
+});
+
+window.RegionsCollection = Backbone.Collection.extend({
+    model: window.RegionDetailsModel
 });
 
 window.AppModel = Backbone.Model.extend({
@@ -19,8 +39,6 @@ window.AppModel = Backbone.Model.extend({
     defaults: {
         statsList: null,
         partnerModalLinks: null,
-        detailsVisible: false,
-        selectedRegion: null,
         initialMapCenter: null,
         initialMapZoom: null,
         baseMapTilesMinZoom: null,
@@ -32,37 +50,8 @@ window.AppModel = Backbone.Model.extend({
         regionLayerOpacity: null,
     },
 
-    initialize: function() {
-        this.hideDetails = this.hideDetails.bind(this);
-        this.showDetails = this.showDetails.bind(this);
-    },
-
-    hideDetails: function() {
-        this.set({
-            detailsVisible: false,
-            selectedRegion: null,
-        });
-        return _.noop();
-    },
-
-    showDetails: function(regionName) {
-        var selectedRegion = null;
-
-        if (!regionName) {
-            return _.noop();
-        }
-
-        selectedRegion = _.findWhere(this.get('regionList'), { title: regionName });
-
-        if (!selectedRegion) {
-            return _.noop();
-        }
-
-        this.set({
-            selectedRegion: new RegionDetailsModel(selectedRegion),
-            detailsVisible: true,
-        });
-
-        return _.noop();
-    },
+    getSelectedRegion: function() {
+        return this.get('regionList')
+            .filter({ selected: true })[0];
+    }
 });


### PR DESCRIPTION
## Overview

Refactors the existing code to make better use of Backbone models and views, and to conform to Backbone best practices. These changes reduce the need for custom state management and rendering code, and take advantage of some built-in Backbone features.

This was all in anticipation of implementing fly-to transitions and detail views for subregions, which required coordination between the map and sidebar. This is made easier by instantiating the regions and subregions as models, which have state that can be accessed throughout the app.

When a user clicks on a subregion in the sidebar, the description of the subregion is animated in below the subregion button. Also, the map does a fly-to transition to the subregion location and opens the subregion popup. Selecting another subregion in the same region closes the initial popup and transitions to the selected region. Exiting the region closes the popup, removes the markers, and transitions back to the initial map state.

Connects #32 

## Demo

![tnc1](https://user-images.githubusercontent.com/1042475/32909238-1e5a3218-cad4-11e7-83c9-c7572a4a2024.gif)

## Note

The animations are smoother than they appear in the above gif.

## Testing Instructions

- Select a region, and then select various subregions in that region.
- Verify that when you select a subregion, the map focuses on that subregion and opens the subregion popup.
- Verify that exiting out of the region closes any open popups and removes the markers, like before.